### PR TITLE
use type checking for IPC api

### DIFF
--- a/electron/src/IElectronBridge.ts
+++ b/electron/src/IElectronBridge.ts
@@ -1,6 +1,32 @@
-export interface IElectronBridge extends Record<string, any>{
-    cliResult(result: string): void;
-    cliArgs(): string;
-    openFileDialog(options: Electron.OpenDialogOptions, code: string): Promise<Electron.OpenDialogReturnValue>;
-    openMessageDialog(options: Electron.MessageBoxOptions, code: string): Promise<Electron.MessageBoxReturnValue>;
+interface IElectronBridgeSync {
+  writeResultToStdOutAndExit(result: string): void;
+  getCommandLineArguments(): string[];
 }
+
+interface IElectronBridgeAsync {
+  openFileDialog(options: Electron.OpenDialogOptions): Promise<Electron.OpenDialogReturnValue>;
+  openMessageDialog(options: Electron.MessageBoxOptions): Promise<Electron.MessageBoxReturnValue>;
+}
+
+export interface IElectronBridge extends IElectronBridgeSync, IElectronBridgeAsync {
+}
+
+export const responseChannelNameFor = <T extends string> (channelName: T) => `${channelName}-response` as const;
+export const exceptionCodeFor = <T extends string> (code: T) => `exception:${code}` as const;
+
+export type ElectronIpcSyncRequestChannelName = keyof IElectronBridgeSync;
+export type ElectronIpcAsyncRequestChannelName = keyof IElectronBridgeAsync;
+
+export type ElectronBridgeAsyncApiRequest<ElectronBridgeApiChannelName extends ElectronIpcAsyncRequestChannelName> =
+  Parameters<IElectronBridge[ElectronBridgeApiChannelName]>;
+ 
+type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T;
+export type ElectronBridgeAsyncApiResponse<ElectronBridgeApiChannelName extends ElectronIpcAsyncRequestChannelName> =
+  Awaited<ReturnType<IElectronBridge[ElectronBridgeApiChannelName]>>;
+
+export type ElectronBridgeSyncApiRequest<ElectronBridgeApiChannelName extends ElectronIpcSyncRequestChannelName> =
+  Parameters<IElectronBridge[ElectronBridgeApiChannelName]>;
+  
+export type ElectronBridgeSyncApiResponse<ElectronBridgeApiChannelName extends ElectronIpcSyncRequestChannelName> =
+  ReturnType<IElectronBridge[ElectronBridgeApiChannelName]>;
+

--- a/electron/src/electron.ts
+++ b/electron/src/electron.ts
@@ -108,13 +108,20 @@ implementSyncApi( "writeResultToStdOutAndExit", (result) => {
   process.stdout.write('\n');
   process.exit(0)
 });
-implementSyncApi( "getCommandLineArguments", () => 
+implementSyncApi( "getCommandLineArguments", () => {
   /**
-    The first two arguments are the path and the executable name, so the actual command line arguments start at index 2.
+    When executed with electron command the first two arguments are the path and the executable name,
+    so the actual command line arguments start at index 2. When executed as packed binary the actual
+    command line arguments start at index 1.
     See: https://nodejs.org/docs/latest/api/process.html#process_process_argv.
-    The constant represents only the arguments that follow the path and executable nae.
+    The constant represents only the arguments that follow the path and executable name.
   */
-  process.argv.slice(2)
- );
+  const argv = process.argv
+  if(argv[0].toLowerCase().endsWith("electron")){
+      return argv.slice(2)
+  }else{
+      return argv.slice(1)
+  }
+});
 implementAsyncApi( "openFileDialog", (options) => dialog.showOpenDialog(mainWindow, options) );
 implementAsyncApi( "openMessageDialog", (options) => dialog.showMessageBox(mainWindow, options) );

--- a/electron/src/electron.ts
+++ b/electron/src/electron.ts
@@ -2,14 +2,22 @@ import {app, BrowserWindow, dialog, ipcMain} from 'electron';
 import * as path from 'path';
 
 import * as squirrelCheck from './electron-squirrel-startup'
+import {
+  ElectronIpcAsyncRequestChannelName,
+  ElectronBridgeAsyncApiRequest,
+  ElectronBridgeAsyncApiResponse,
+  exceptionCodeFor,
+  responseChannelNameFor,
+  ElectronIpcSyncRequestChannelName,
+  ElectronBridgeSyncApiResponse,
+  ElectronBridgeSyncApiRequest
+} from './IElectronBridge';
 import ipcRenderer = Electron.Renderer.ipcRenderer;
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (squirrelCheck()) {
     app.quit();
 }
-
-const cliArgs = process.argv.slice(2);
 
 let mainWindow: BrowserWindow
 
@@ -73,26 +81,40 @@ if (instanceLock) {
     app.quit()
 }
 
-// Return value and exit
-ipcMain.on("cli-result", (event, result) => {
-    process.stdout.write(result);
-    process.stdout.write('\n');
-    process.exit(0)
-})
 
-// Return cli arguments
-ipcMain.on('cli-args', (event, arg) => {
-    event.returnValue = cliArgs
-})
+const implementSyncApi = <CHANNEL extends ElectronIpcSyncRequestChannelName>(channel: CHANNEL, implementation: (...args: ElectronBridgeSyncApiRequest<CHANNEL>) => ElectronBridgeSyncApiResponse<CHANNEL>) => {
+  const responseChannelName = responseChannelNameFor(channel);
+  ipcMain.on(channel, (event, ...args) => {
+    try {
+      event.returnValue = implementation(...(args as ElectronBridgeSyncApiRequest<CHANNEL>));
+    } catch (e) {
+      event.returnValue = e;
+    }
+  })
+}
+const implementAsyncApi = <CHANNEL extends ElectronIpcAsyncRequestChannelName>(channel: CHANNEL, implementation: (...args: ElectronBridgeAsyncApiRequest<CHANNEL>) => Promise<ElectronBridgeAsyncApiResponse<CHANNEL>>) => {
+  const responseChannelName = responseChannelNameFor(channel);
+  ipcMain.on(channel, (event, code, ...args) => {
+    implementation(...args as ElectronBridgeAsyncApiRequest<CHANNEL>).then( response =>
+      event.sender.send(responseChannelName, code, response)
+    ).catch( exception =>
+      event.sender.send(responseChannelName, exceptionCodeFor(code), exception)
+    )
+  })
+}
 
-ipcMain.on('open-file-dialog', (event, options, code) => {
-    dialog.showOpenDialog(mainWindow, options).then((value) => {
-        event.sender.send('open-file-dialog-response', value, code);
-    })
+implementSyncApi( "writeResultToStdOutAndExit", (result) => {
+  process.stdout.write(result);
+  process.stdout.write('\n');
+  process.exit(0)
 });
-
-ipcMain.on('open-message-dialog', (event, options, code) => {
-    dialog.showMessageBox(options).then((value) => {
-        event.sender.send('open-message-dialog-response', value, code)
-    });
-});
+implementSyncApi( "getCommandLineArguments", () => 
+  /**
+    The first two arguments are the path and the executable name, so the actual command line arguments start at index 2.
+    See: https://nodejs.org/docs/latest/api/process.html#process_process_argv.
+    The constant represents only the arguments that follow the path and executable nae.
+  */
+  process.argv.slice(2)
+ );
+implementAsyncApi( "openFileDialog", (options) => dialog.showOpenDialog(mainWindow, options) );
+implementAsyncApi( "openMessageDialog", (options) => dialog.showMessageBox(mainWindow, options) );

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -25,14 +25,14 @@ const createIpcAsyncRequestClientFunction = <CHANNEL extends ElectronIpcAsyncReq
     const responseChannel = responseChannelNameFor(channel)
     // Create a listener function that will resolve the promise and stop listening when
     // the event code matches
-    const responseListener = (event: Electron.IpcRendererEvent, value: ElectronBridgeAsyncApiResponse<CHANNEL>, eventCode: string) => {
+    const responseListener = (event: Electron.IpcRendererEvent, eventCode: string, response: ElectronBridgeAsyncApiResponse<CHANNEL>) => {
       if (eventCode === exceptionCodeFor(codeToMatch) ) {
         // The value is actually an exception and we should reject the promise.
-        reject(value);
+        reject(response);
         ipcRenderer.removeListener(responseChannel, responseListener);
       } else if (eventCode === codeToMatch) {
         // The response code matches the request and so we should resolve the request
-        resolve(value)
+        resolve(response)
         ipcRenderer.removeListener(responseChannel, responseListener);
       }
     }

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -2,39 +2,53 @@
 // It has the same sandbox as a Chrome extension.
 import { IElectronBridge } from "./IElectronBridge";
 import {contextBridge, ipcRenderer} from "electron";
+import {
+  ElectronIpcAsyncRequestChannelName,
+  ElectronIpcSyncRequestChannelName,
+  ElectronBridgeAsyncApiRequest,
+  ElectronBridgeSyncApiRequest,
+  ElectronBridgeAsyncApiResponse,
+  ElectronBridgeSyncApiResponse,
+  exceptionCodeFor,
+  responseChannelNameFor,
+} from "./IElectronBridge";
 
-contextBridge.exposeInMainWorld('ElectronBridge', {
-    // Return result in stdout and quit
-    cliResult: (result: string) => {
-        ipcRenderer.send("cli-result", result)
-    },
-    // Get cli args
-    cliArgs: () => {
-        return ipcRenderer.sendSync('cli-args')
-    },
-    openFileDialog: (options: Electron.OpenDialogOptions, code: string) => {
-        return new Promise<Electron.OpenDialogReturnValue>(function(resolve, reject){
-            ipcRenderer.on('open-file-dialog-response' , function listener(event, value, eventCode){
-                if(code === eventCode){
-                    resolve(value)
-                    ipcRenderer.removeListener('open-file-dialog-response', listener)
-                }
-            });
+const createIpcSyncRequestClientFunction = <CHANNEL extends ElectronIpcSyncRequestChannelName>(channel: CHANNEL) =>
+  (...args: ElectronBridgeSyncApiRequest<CHANNEL>) => ipcRenderer.sendSync(channel, ...args) as ElectronBridgeSyncApiResponse<CHANNEL>
 
-            ipcRenderer.send('open-file-dialog', options, code)
-        });
-    },
-    openMessageDialog: (options: Electron.MessageBoxOptions, code: string) => {
-        return new Promise<Electron.MessageBoxReturnValue>(function(resolve, reject){
-            ipcRenderer.on('open-message-dialog-response' , function listener(event, value, eventCode){
-                if(code === eventCode){
-                    resolve(value)
-                    ipcRenderer.removeListener('open-message-dialog-response', listener)
-                }
-            });
-
-            ipcRenderer.send('open-message-dialog', options, code)
-        });
+const createIpcAsyncRequestClientFunction = <CHANNEL extends ElectronIpcAsyncRequestChannelName>(channel: CHANNEL) =>
+  (...args: ElectronBridgeAsyncApiRequest<CHANNEL>) =>
+  new Promise<ElectronBridgeAsyncApiResponse<CHANNEL>>( (resolve, reject) => {
+    // Create a code that allows us to match requests to responses
+    const codeToMatch = `${Math.random()}:${Math.random()}`;
+    // The response channel name is the name of the request channel type with suffix "-response" added
+    const responseChannel = responseChannelNameFor(channel)
+    // Create a listener function that will resolve the promise and stop listening when
+    // the event code matches
+    const responseListener = (event: Electron.IpcRendererEvent, value: ElectronBridgeAsyncApiResponse<CHANNEL>, eventCode: string) => {
+      if (eventCode === exceptionCodeFor(codeToMatch) ) {
+        // The value is actually an exception and we should reject the promise.
+        reject(value);
+        ipcRenderer.removeListener(responseChannel, responseListener);
+      } else if (eventCode === codeToMatch) {
+        // The response code matches the request and so we should resolve the request
+        resolve(value)
+        ipcRenderer.removeListener(responseChannel, responseListener);
+      }
     }
+    // Start listening for response just before sending the request
+    ipcRenderer.on(responseChannel, responseListener);
+    // Send the request
+    ipcRenderer.send(channel, codeToMatch, ...args);
+  });
 
-} as IElectronBridge)
+// Create the API to expose, using TypeScript to verify that we created everything correctly
+const electronBridgeTypeChecked: IElectronBridge = {
+  writeResultToStdOutAndExit: createIpcSyncRequestClientFunction("writeResultToStdOutAndExit"),
+  getCommandLineArguments: createIpcSyncRequestClientFunction("getCommandLineArguments"),
+  openFileDialog: createIpcAsyncRequestClientFunction("openFileDialog"),
+  openMessageDialog: createIpcAsyncRequestClientFunction("openMessageDialog"),
+};
+
+// Expose the API
+contextBridge.exposeInMainWorld('ElectronBridge', electronBridgeTypeChecked);


### PR DESCRIPTION
@angelix I haven't tested these changes, but by giving TypeScript the opportunity to check the prior code I found multiple bugs:

1.  getArgs was shown as returning `string` when it actually returned `string[]`
2. showMessageBox was getting passed the wrong first parameter because that parameter was `any`.

I also added exception handling.

Hopefully all the handy type checking makes it easier to add more IPC if we need them as we move forward.
