### PR TITLE
Add built-in recipes for PGP/SSH

### DIFF
--- a/web/src/dicekeys/StoredRecipe.ts
+++ b/web/src/dicekeys/StoredRecipe.ts
@@ -55,7 +55,9 @@ export const BuiltInRecipes: StoredRecipe[] = [
 	new BuiltInRecipe("Password", "Google", `{"allow":[{"host":"*.google.com"}]}`),
 	new BuiltInRecipe("Password", "Keeper", `{"allow":[{"host":"*.keepersecurity.com"},{"host":"*.keepersecurity.eu"}]}`),
 	new BuiltInRecipe("Password", "LastPass", `{"allow":[{"host":"*.lastpass.com"}]}`),
-	new BuiltInRecipe("Password", "Microsoft", `{"allow":[{"host":"*.microsoft.com"},{"host":"*.live.com"}]}`)  
+	new BuiltInRecipe("Password", "Microsoft", `{"allow":[{"host":"*.microsoft.com"},{"host":"*.live.com"}]}`),
+	new BuiltInRecipe("SigningKey", "SSH", `{"purpose": "ssh"}`),
+	new BuiltInRecipe("SigningKey", "PGP", `{"purpose": "pgp"}`),
 ];
 
 

--- a/web/src/dicekeys/StoredRecipe.ts
+++ b/web/src/dicekeys/StoredRecipe.ts
@@ -56,8 +56,8 @@ export const BuiltInRecipes: StoredRecipe[] = [
 	new BuiltInRecipe("Password", "Keeper", `{"allow":[{"host":"*.keepersecurity.com"},{"host":"*.keepersecurity.eu"}]}`),
 	new BuiltInRecipe("Password", "LastPass", `{"allow":[{"host":"*.lastpass.com"}]}`),
 	new BuiltInRecipe("Password", "Microsoft", `{"allow":[{"host":"*.microsoft.com"},{"host":"*.live.com"}]}`),
-	new BuiltInRecipe("SigningKey", "SSH", `{"purpose": "ssh"}`),
-	new BuiltInRecipe("SigningKey", "PGP", `{"purpose": "pgp"}`),
+	new BuiltInRecipe("SigningKey", "SSH", `{"purpose":"ssh"}`),
+	new BuiltInRecipe("SigningKey", "PGP", `{"purpose":"pgp"}`),
 ];
 
 

--- a/web/src/views/Recipes/DerivedFromRecipeState.ts
+++ b/web/src/views/Recipes/DerivedFromRecipeState.ts
@@ -5,19 +5,22 @@ import { isValidJson } from "../../utilities/json";
 import { SeededCryptoModulePromise } from "@dicekeys/seeded-crypto-js";
 import { AsyncCalculation } from "../../utilities/AsyncCalculation";
 import { DiceKeyWithKeyId } from "../../dicekeys/DiceKey";
+import { defaultOnException } from "../../utilities/default-on-exception";
 
 const spaceJson = (spaces: number = 2) => (json: string | undefined): string | undefined => {
   return (json == null) ? json : JSON.stringify(JSON.parse(json), undefined, spaces);
 }
 const doubleSpaceJson = spaceJson(2);
 
+const OpenPGP_Private_Key = "OpenPGP Private Key" as const;
+const OpenSSH_Private_Key = "OpenSSH Private Key" as const;
 export const OutputFormats = {
   "Password": ["Password", "JSON"],
   "Secret": ["JSON", "Hex", "BIP39"],
   "SigningKey": [
     "JSON",
-    "OpenPGP Private Key",
-    "OpenSSH Private Key",
+    OpenPGP_Private_Key,
+    OpenSSH_Private_Key,
     "OpenSSH Public Key",
     "Hex (Signing Key)",
     /* "Hex (Signature-Verification Key)" */
@@ -27,12 +30,12 @@ export const OutputFormats = {
 } as const;
 type OutputFormats = typeof OutputFormats;
 export type OutputFormat<T extends DerivationRecipeType = DerivationRecipeType> = OutputFormats[T][number]
-export type OutputFormatForType<T extends DerivationRecipeType = DerivationRecipeType> = {[type in T]: OutputFormat<T>}
+export type OutputFormatForType<T extends DerivationRecipeType = DerivationRecipeType> = {[type in DerivationRecipeType]?: OutputFormat<T>}
 ( () => {
   const TypeCheckOutputFormats: Record<DerivationRecipeType, readonly string[]> = OutputFormats;
   if (false) console.log(`${TypeCheckOutputFormats}`)
 })
-const DefaultOutputFormat: OutputFormatForType =  {
+const DefaultOutputFormat =  {
   "Password": "Password",
   "Secret": "Hex",
   "SigningKey": "JSON",
@@ -45,6 +48,11 @@ export interface RecipeState {
   type?: DerivationRecipeType;
   recipeJson?: string;
   recipeIsValid: boolean;
+}
+
+interface SecretTypeAndOutputType<SECRET_TYPE extends DerivationRecipeType = DerivationRecipeType> {
+  type: SECRET_TYPE;
+  outputFormat: OutputFormat<SECRET_TYPE>
 }
 
 export class DerivedFromRecipeState {
@@ -61,8 +69,25 @@ export class DerivedFromRecipeState {
   //////////////////////////////////////////
   // outputField to derive from recipe
   //////////////////////////////////////////  
-  outputFieldForType: OutputFormatForType = {...DefaultOutputFormat};
-  outputFieldFor = <T extends DerivationRecipeType>(t: T): OutputFormat<T> => this.outputFieldForType[t];
+  outputFieldForType: OutputFormatForType = {};
+  outputFieldFor = <T extends DerivationRecipeType>(t: T): OutputFormat<T> => {
+    const outputFormatChosenByUser = this.outputFieldForType[t] as OutputFormat<T>;
+    if (outputFormatChosenByUser != null) {
+      return outputFormatChosenByUser;
+    }
+    const purposeLowerCase = defaultOnException(() =>
+      (JSON.parse(this.recipeState.recipeJson ?? "{}") as {purpose?: string})?.purpose?.toLocaleLowerCase()
+    );
+    // If this is a signing key and the name includes "pgp", default the output format to PGP private key
+    if (t === "SigningKey" && purposeLowerCase?.includes("pgp")) {
+      return OpenPGP_Private_Key;
+    }
+    // If this is a signing key and the name includes "ssh", default the output format to an SSH private key
+    if (t === "SigningKey" && purposeLowerCase?.includes("ssh")) {
+      return OpenSSH_Private_Key;
+    }
+    return DefaultOutputFormat[t];
+  };
   setOutputField = action ( (value: OutputFormat<DerivationRecipeType>) => {
     const recipeType = this.recipeState.type;
     if (recipeType != null && (OutputFormats[recipeType] as readonly string[]).indexOf(value) != -1) {
@@ -70,6 +95,13 @@ export class DerivedFromRecipeState {
     }
   });
   setOutputFieldTo = (value: OutputFormat<DerivationRecipeType>) => () => this.setOutputField(value);
+
+  get secretTypeAndOutputType(): SecretTypeAndOutputType | undefined {
+    const {type} = this.recipeState;
+    if (type == null) return;
+    const outputFormat = this.outputFieldFor(type);
+    return {type, outputFormat};
+  }
 
   constructor({recipeState, diceKey}: {recipeState: RecipeState, diceKey: DiceKeyWithKeyId | undefined} ) {
     this.recipeState = recipeState;
@@ -88,85 +120,89 @@ export class DerivedFromRecipeState {
 
   get derivedValue(): string | undefined {
     const {recipeState, api} = this;
-    const {type, recipeJson, recipeIsValid} = recipeState;
-    if (!type || !isValidJson(recipeJson) || !recipeIsValid) return;
-  
+    const {recipeJson, recipeIsValid} = recipeState;
+    const secretTypeAndOutputType = this.secretTypeAndOutputType;
+    if (secretTypeAndOutputType == null || !isValidJson(recipeJson) || !recipeIsValid) return;
+    const {type, outputFormat} = secretTypeAndOutputType;
+
     switch (type) {
-      case "Password":
-        switch (this.outputFieldFor("Password")) {
-          case "Password":
-            return api?.getPasswordForRecipe(recipeJson);
-          case "JSON":
-            return doubleSpaceJson(api?.getPasswordJsonForRecipe(recipeJson))
-        }
-      case "Secret":
-        switch (this.outputFieldFor("Secret")) {
-          case "BIP39":
-            return api?.getSecretBip39ForRecipe(recipeJson);
-          case "Hex":
-            return api?.getSecretHexForRecipe(recipeJson);
-          case "JSON":
-            return doubleSpaceJson(api?.getSecretJsonForRecipe(recipeJson));
-        }
-      case "SymmetricKey":
-        switch (this.outputFieldFor("SymmetricKey")) {
-          case "Hex":
-            return api?.getSymmetricKeyHexForRecipe(recipeJson);
-          case "JSON":
-            return doubleSpaceJson(api?.getSymmetricKeyJsonForRecipe(recipeJson));
-        }
-      case "UnsealingKey":
-        switch (this.outputFieldFor("UnsealingKey")) {
-          case "Hex (Unsealing Key)":
-            return api?.getUnsealingKeyHexForRecipe(recipeJson);
-          case "Hex (Sealing Key)":
-            return api?.getSealingKeyHexForRecipe(recipeJson);
-          case "JSON":
-            return doubleSpaceJson(api?.getUnsealingKeyJsonForRecipe(recipeJson));
-        }
-      case "SigningKey":
-        switch (this.outputFieldFor("SigningKey")) {
-          case "Hex (Signing Key)":
-            return api?.getSigningKeyHexForRecipe(recipeJson);
-          case "OpenPGP Private Key": {
-            const signingKeyJson = api?.getSigningKeyJsonForRecipe(recipeJson);
-            if (signingKeyJson == null) return undefined;
-            return this.SigningCalculations.get(`${this.outputFieldFor("SigningKey")}:${recipeJson}}`, async () => {
-              const signingKey = (await SeededCryptoModulePromise)?.SigningKey.fromJson(signingKeyJson);
-              try {
-                return signingKey.toOpenPgpPemFormatSecretKey("" /*user id*/, Math.floor(Date.now() / 1000));
-              } finally {
-                signingKey.delete();
-              }                
-            })
+        case "Password":
+          // Someday, maybe typescript will correctly manage this output format!
+          switch (outputFormat as OutputFormat<"Password">) {
+          // switch (this.outputFieldFor("Password")) {
+            case "Password":
+              return api?.getPasswordForRecipe(recipeJson);
+            case "JSON":
+              return doubleSpaceJson(api?.getPasswordJsonForRecipe(recipeJson))
           }
-          case "OpenSSH Private Key": {
-            const signingKeyJson = api?.getSigningKeyJsonForRecipe(recipeJson);
-            if (signingKeyJson == null) return undefined;
-            return this.SigningCalculations.get(`${this.outputFieldFor("SigningKey")}:${recipeJson}}`, async () => {
-              const signingKey = (await SeededCryptoModulePromise)?.SigningKey.fromJson(signingKeyJson);
-              try {
-                return signingKey.toOpenSshPemPrivateKey("" /* comment */);
-              } finally {
-                signingKey.delete();
-              }                
-            })
+        case "Secret":
+          switch (this.outputFieldFor("Secret")) {
+            case "BIP39":
+              return api?.getSecretBip39ForRecipe(recipeJson);
+            case "Hex":
+              return api?.getSecretHexForRecipe(recipeJson);
+            case "JSON":
+              return doubleSpaceJson(api?.getSecretJsonForRecipe(recipeJson));
           }
-          case "OpenSSH Public Key": {
-            const signingKeyJson = api?.getSigningKeyJsonForRecipe(recipeJson);
-            if (signingKeyJson == null) return undefined;
-            return this.SigningCalculations.get(`${this.outputFieldFor("SigningKey")}:${recipeJson}}`, async () => {
-              const signingKey = (await SeededCryptoModulePromise)?.SigningKey.fromJson(signingKeyJson);
-              try {
-                return signingKey.toOpenSshPublicKey();
-              } finally {
-                signingKey.delete();
-              }                
-            })
+        case "SymmetricKey":
+          switch (this.outputFieldFor("SymmetricKey")) {
+            case "Hex":
+              return api?.getSymmetricKeyHexForRecipe(recipeJson);
+            case "JSON":
+              return doubleSpaceJson(api?.getSymmetricKeyJsonForRecipe(recipeJson));
           }
-          case "JSON":
-            return doubleSpaceJson(api?.getSigningKeyJsonForRecipe(recipeJson));
-        }
-    }
+        case "UnsealingKey":
+          switch (this.outputFieldFor("UnsealingKey")) {
+            case "Hex (Unsealing Key)":
+              return api?.getUnsealingKeyHexForRecipe(recipeJson);
+            case "Hex (Sealing Key)":
+              return api?.getSealingKeyHexForRecipe(recipeJson);
+            case "JSON":
+              return doubleSpaceJson(api?.getUnsealingKeyJsonForRecipe(recipeJson));
+          }
+        case "SigningKey":
+          switch (this.outputFieldFor("SigningKey")) {
+            case "Hex (Signing Key)":
+              return api?.getSigningKeyHexForRecipe(recipeJson);
+            case "OpenPGP Private Key": {
+              const signingKeyJson = api?.getSigningKeyJsonForRecipe(recipeJson);
+              if (signingKeyJson == null) return undefined;
+              return this.SigningCalculations.get(`${this.outputFieldFor("SigningKey")}:${recipeJson}}`, async () => {
+                const signingKey = (await SeededCryptoModulePromise)?.SigningKey.fromJson(signingKeyJson);
+                try {
+                  return signingKey.toOpenPgpPemFormatSecretKey("" /*user id*/, Math.floor(Date.now() / 1000));
+                } finally {
+                  signingKey.delete();
+                }                
+              })
+            }
+            case "OpenSSH Private Key": {
+              const signingKeyJson = api?.getSigningKeyJsonForRecipe(recipeJson);
+              if (signingKeyJson == null) return undefined;
+              return this.SigningCalculations.get(`${this.outputFieldFor("SigningKey")}:${recipeJson}}`, async () => {
+                const signingKey = (await SeededCryptoModulePromise)?.SigningKey.fromJson(signingKeyJson);
+                try {
+                  return signingKey.toOpenSshPemPrivateKey("" /* comment */);
+                } finally {
+                  signingKey.delete();
+                }                
+              })
+            }
+            case "OpenSSH Public Key": {
+              const signingKeyJson = api?.getSigningKeyJsonForRecipe(recipeJson);
+              if (signingKeyJson == null) return undefined;
+              return this.SigningCalculations.get(`${this.outputFieldFor("SigningKey")}:${recipeJson}}`, async () => {
+                const signingKey = (await SeededCryptoModulePromise)?.SigningKey.fromJson(signingKeyJson);
+                try {
+                  return signingKey.toOpenSshPublicKey();
+                } finally {
+                  signingKey.delete();
+                }                
+              })
+            }
+            case "JSON":
+              return doubleSpaceJson(api?.getSigningKeyJsonForRecipe(recipeJson));
+          }
+      }
   };
 }


### PR DESCRIPTION
Add two new built-ins.

Change the default output format for values derived from secrets so that signing keys with purpose containing "pgp" (case insensitive) default to PGP private output format and with "ssh" (case insensitive) default to SSH private output format.